### PR TITLE
chore: upgrade to react-email 6

### DIFF
--- a/emails/welcome.tsx
+++ b/emails/welcome.tsx
@@ -10,7 +10,7 @@ import {
   Section,
   Tailwind,
   Text,
-} from '@react-email/components';
+} from 'react-email';
 import { createTranslator } from 'next-intl';
 
 interface WelcomeEmailProps {

--- a/package.json
+++ b/package.json
@@ -6,16 +6,15 @@
     "export": "email export"
   },
   "dependencies": {
-    "@react-email/components": "1.0.4",
+    "@react-email/ui": "6.0.0",
     "next-intl": "4.7.0",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
   "devDependencies": {
-    "@react-email/preview-server": "5.2.3",
     "@types/react": "19.2.8",
     "@types/react-dom": "19.2.3",
-    "react-email": "5.2.3",
+    "react-email": "6.0.0",
     "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
Upgrades to [react-email 6](https://react.email/docs/getting-started/updating-react-email#update-from-react-email-5-0-to-6-0).

- Remove `@react-email/components` and `@react-email/preview-server`
- Add `react-email@6` and `@react-email/ui@6`
- Update imports in `emails/welcome.tsx` from `@react-email/components` to `react-email`